### PR TITLE
feat: support `date` from io-ts-types.  This new dependency is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Quick Start
 
-After `yarn add io-ts io-ts-fuzzer`...
+After `yarn add fp-ts io-ts io-ts-fuzzer`...
 
 ````typescript
 import * as t from 'io-ts';
@@ -31,7 +31,7 @@ console.log(fuzzer.encode([493, fuzz.fuzzContext()]));
 
 ## Types Supported
 
-Currently supports (and their nested closure):
+Currently supports (along with their nested closure):
 
 * `t.array`
 * `t.boolean`
@@ -54,6 +54,10 @@ Currently supports (and their nested closure):
 * `t.unknown`
 * `t.UnknownArray`
 * `t.void`
+
+If you additionally do `yarn add monocle-ts io-ts-types` and register
+the `io-ts-types` extra fuzzers via `r.register(...await loadIoTsTypesFuzzers)`, the following additional types will be supported:
+* `date`
 
 ## Use Cases
 

--- a/package.json
+++ b/package.json
@@ -115,9 +115,15 @@
     "concurrently": "^4.1.1",
     "gts": "^1.1.0",
     "husky": "^3.0.2",
+    "io-ts-types": "^0.5.0",
     "mocha": "^6.2.0",
+    "monocle-ts": "^2.0.0",
     "nyc": "^14.1.1",
     "ts-mocha": "^6.0.0",
     "typescript": "~3.5.0"
+  },
+  "peerDependencies": {
+    "io-ts-types": "^0.5.0",
+    "monocle-ts": "^2.0.0"
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,1 +1,0 @@
-export { coreFuzzers, arrayFuzzer } from './core';

--- a/src/extra-fuzzers/io-ts-types.ts
+++ b/src/extra-fuzzers/io-ts-types.ts
@@ -1,0 +1,8 @@
+import { FuzzContext, concreteFuzzerByName } from '../fuzzer';
+import { rngi } from '../rng';
+
+export function fuzzDate(_: FuzzContext, n: number): Date {
+  return new Date(rngi(n) / 1000.0);
+}
+
+export const fuzzers = [concreteFuzzerByName(fuzzDate, 'Date')];

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,0 +1,12 @@
+import { Fuzzer } from './fuzzer';
+
+async function loadExtras(str: string): Promise<Array<Fuzzer<unknown>>> {
+  const x = (await import(`./extra-fuzzers/${str}`)) as {
+    fuzzers: Array<Fuzzer<unknown>>;
+  };
+  return x.fuzzers;
+}
+
+export async function loadIoTsTypesFuzzers(): Promise<Array<Fuzzer<unknown>>> {
+  return loadExtras('io-ts-types');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,7 @@ Third-party dependencies may have their own licenses.
 
 export * from './registry';
 export * from './fuzzer';
-export * from './core/';
+export * from './extras';
+
+import * as core from './core';
+export { core };

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,13 +1,14 @@
 import { Fuzzer, ExampleGenerator, exampleGenerator } from './fuzzer';
 import * as t from 'io-ts';
-import { coreFuzzers, arrayFuzzer } from './core/';
 import {
   partialFuzzer,
   interfaceFuzzer,
   readonlyArrayFuzzer,
   anyArrayFuzzer,
   unknownFuzzer,
-} from './core/core';
+  arrayFuzzer,
+  coreFuzzers,
+} from './core';
 
 export interface Registry {
   register<T, U extends t.Decoder<unknown, T>>(v0: Fuzzer<T, U>): Registry;

--- a/src/rng.ts
+++ b/src/rng.ts
@@ -1,0 +1,9 @@
+import * as rnd from 'seedrandom';
+
+export function rng(seed: number) {
+  return rnd.tychei(`${seed}`, { global: false });
+}
+
+export function rngi(seed: number) {
+  return Math.abs(rng(seed).int32());
+}

--- a/test/extra-fuzzers/test-io-ts-types.ts
+++ b/test/extra-fuzzers/test-io-ts-types.ts
@@ -1,0 +1,56 @@
+import * as assert from 'assert';
+import * as lib from '../../src/extras';
+
+import {
+  exampleGenerator,
+  fuzzContext,
+  FuzzContext,
+  createCoreRegistry,
+} from '../../src/';
+import { isRight, Right } from 'fp-ts/lib/Either';
+import { date } from 'io-ts-types/lib/date';
+import { Encode } from 'io-ts';
+
+const count = 100;
+
+const types = [date];
+
+describe('extra-fuzzers', () => {
+  describe('io-ts-types', () => {
+    for (const b of types) {
+      describe(`\`${b.name}\` codec`, () => {
+        let p: Encode<[number, FuzzContext], unknown>;
+        const old: unknown[] = [];
+        it(`loads extra fuzzers and builds an example generator`, async () => {
+          const r = createCoreRegistry()!;
+          const fz = await lib.loadIoTsTypesFuzzers();
+          r.register(...fz);
+          p = exampleGenerator(r, b).encode;
+        });
+        it(`generates unique, decodable examples for inputs '[0, ${count})`, () => {
+          for (const n of new Array(count).keys()) {
+            const v = p([n, fuzzContext()]);
+            const d = b.decode(v);
+            assert.ok(isRight(d), `must decode ${JSON.stringify(v)}`);
+            assert.deepStrictEqual(
+              (d as Right<unknown>).right,
+              v,
+              `must decode ${JSON.stringify(v)}`
+            );
+            old.push(v);
+          }
+        })
+          .timeout(5000)
+          .slow(500);
+        it(`generates same examples 2nd time`, () => {
+          for (const n of new Array(count).keys()) {
+            const v = p([n, fuzzContext()]);
+            assert.deepStrictEqual(v, old[n]);
+          }
+        })
+          .timeout(5000)
+          .slow(500);
+      });
+    }
+  });
+});

--- a/test/test-core.ts
+++ b/test/test-core.ts
@@ -1,7 +1,8 @@
 import { assert } from 'chai';
-import { fuzzUnion, unknownFuzzer } from '../src/core/core';
 import * as t from 'io-ts';
-import { fuzzContext, FuzzerUnit, Fuzzer } from '../src';
+
+import { fuzzUnion, unknownFuzzer } from '../src/core';
+import { fuzzContext, FuzzerUnit, Fuzzer } from '../src/fuzzer';
 
 // tslint:disable-next-line:variable-name
 const RecA: t.RecursiveType<t.UnionType<t.Mixed[]>> = t.recursion('RecA', () =>
@@ -55,7 +56,7 @@ const fuNonRecursiveObject: FuzzerUnit<object> = {
 
 describe('core', () => {
   describe('fuzzUnion', () => {
-    it('returns any subtype when shouldGoDeeper', () => {
+    it('returns any subtype when mayRecurse', () => {
       const c = fuzzUnion(RecA.type);
       const s = new Set<unknown>();
       for (const i of new Array(count).keys()) {
@@ -72,7 +73,7 @@ describe('core', () => {
       assert.sameMembers(Array.from(s), [10, '15', ro]);
     });
 
-    it('returns any subtype when !shouldGoDeeper and no recursive types', () => {
+    it('returns any subtype when !mayRecurse and no recursive types', () => {
       const c = fuzzUnion(RecA.type);
       const s = new Set<unknown>();
       for (const i of new Array(count).keys()) {
@@ -89,7 +90,7 @@ describe('core', () => {
       assert.sameMembers(Array.from(s), [10, '15', ro]);
     });
 
-    it('returns available non-recursive subtypes when !shouldGoDeeper', () => {
+    it('returns available non-recursive subtypes when !mayRecurse', () => {
       const c = fuzzUnion(RecA.type);
       const s = new Set<unknown>();
       for (const i of new Array(count).keys()) {
@@ -106,7 +107,7 @@ describe('core', () => {
       assert.sameMembers(Array.from(s), [10, '15']);
     });
 
-    it('returns any subtype when !shouldGoDeeper and no non-recursive subtypes', () => {
+    it('returns any subtype when !mayRecurse and no non-recursive subtypes', () => {
       const c = fuzzUnion(RecA.type);
       const s = new Set<unknown>();
       for (const i of new Array(count).keys()) {
@@ -136,7 +137,7 @@ describe('core', () => {
       const fuStringSpy: FuzzerUnit<string> = {
         mightRecurse: false,
         encode: ctx => {
-          childDeeper.add(ctx[1].shouldGoDeeper());
+          childDeeper.add(ctx[1].mayRecurse());
           return '15';
         },
       };
@@ -158,7 +159,7 @@ describe('core', () => {
       const fuStringSpy: FuzzerUnit<string> = {
         mightRecurse: false,
         encode: ctx => {
-          childDeeper.add(ctx[1].shouldGoDeeper());
+          childDeeper.add(ctx[1].mayRecurse());
           return '15';
         },
       };
@@ -169,7 +170,7 @@ describe('core', () => {
       assert.sameMembers(Array.from(childDeeper), [true]);
     });
 
-    it('returns default value when !shouldGoDeeper', () => {
+    it('returns default value when !mayRecurse', () => {
       const c0 = unknownFuzzer(t.string) as Fuzzer<unknown>;
       if (c0.impl.type !== 'generator') {
         throw new Error();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,9 +1758,9 @@ form-data@~2.3.2:
     mime-types "^2.1.12"
 
 fp-ts@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.0.3.tgz#b6af5481aa5df027de250bacefa19d36d79edd51"
-  integrity sha512-b/WPo5AVPDYbdye/AGOMST/tqudtgbpMjm3TJGkd36ROihD67UEKFeUH83V3iSdrIG4wwoFsd6lLpjtpek1oVw==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.0.4.tgz#a07ceef59c2460616fcf70367708ebe4d1c2212f"
+  integrity sha512-oRQbFqqGcvorkEj92dAcM4/RH1TARJCt8wVgynRIp8v4uOzVCe4kCs7vKSYpIXQsvtpyCt9nVVFqufSX8VYghg==
 
 from2@^1.3.0:
   version "1.3.0"
@@ -2308,6 +2308,11 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+io-ts-types@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/io-ts-types/-/io-ts-types-0.5.0.tgz#f69be9131362c31bbc6b5044f1d95892604f8f23"
+  integrity sha512-+v88rlA76FmlQQcTImFq5iigoPA3OKO+BIdrpsfXlhWUdiVvOnDDiLKCsiIAW9eRj+OJgG31Sctebr77bqKhzw==
 
 io-ts@^2.0.0:
   version "2.0.1"
@@ -3346,6 +3351,11 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+monocle-ts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/monocle-ts/-/monocle-ts-2.0.0.tgz#f695dbfb5b017846d95f0c377bd4c8acb10f7e02"
+  integrity sha512-vPM02WypUz0Xo2MtLUPgvdelCRn70VT05pdAB7qmHJSNY4CAoQt3ClpH77AG3yZk7PY8CA6++ezHcENUDOiuEA==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
as a peer -- code using it is only imported on calling `loadIoTsTypesFuzzers()`.

BREAKING CHANGE: `core` exports re-organized; some removed.  From here on,
only breaking changes to exports from `index.ts` will be deemed breaking
changes for the package.
